### PR TITLE
demo target databases are not read-only per default

### DIFF
--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -203,8 +203,9 @@ copy_database() {
     # add some metainformation to the copied database as comment
     psql -U pgkogis -d template1 -h localhost -c "COMMENT ON DATABASE ${target_db} IS 'copied from ${source_db} on $(date '+%F %T') with command ${COMMAND} by user ${USER}';" > /dev/null
 
-    # set database to read-only if it is not a _master database
-    if [[ ! ${target} == master ]]; then
+    # set database to read-only if it is not a _master or _demo database
+    REGEX="^(master|demo)$"
+    if [[ ! ${target} =~ ${REGEX} ]]; then
         psql -U pgkogis -h localhost -d template1 -c "alter database ${target_db} SET default_transaction_read_only = on;" >/dev/null
     else
         psql -U pgkogis -h localhost -d template1 -c "alter database ${target_db} SET default_transaction_read_only = off;" >/dev/null


### PR DESCRIPTION
This pull request keeps demo target databases  as read/write databases.
