### PR TITLE
add optional parameter -m

### DIFF
--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -6,7 +6,6 @@
 # copy tables                           [ -s table      -t target   ]
 # archive/snapshot bod                  [ -s bod_master -a 20150303 ]
 MY_DIR=$(dirname $(readlink -f $0))
-source "${MY_DIR}/includes.sh"
 
 display_usage() {
     echo -e "Usage:\n$0 -s source_objects -t target_staging -a timestamp for BOD snapshot/archive (YYYYMMDD)"
@@ -15,7 +14,7 @@ display_usage() {
     echo -e "\t-a is optional and only valid for BOD, if you dont enter a target the script will just create an archive/snapshot copy of the bod\n"
 }
 
-while getopts ":s:t:a:" options; do
+while getopts ":s:t:a:m:" options; do
     case "${options}" in
         s)
             source_objects=${OPTARG}
@@ -27,6 +26,9 @@ while getopts ":s:t:a:" options; do
         a)
             timestamp=${OPTARG}
             ;;
+        m)
+            message=${OPTARG}
+            ;;
         \? )
             display_usage 1>&5 2>&6
             exit 1
@@ -37,6 +39,8 @@ while getopts ":s:t:a:" options; do
             ;;
     esac
 done
+
+source "${MY_DIR}/includes.sh"
 
 #######################################
 # pre-copy checks for tables

--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -10,8 +10,13 @@ SYSLOGPID=$$
 if [[ ${PARENT_COMMAND} == *deploy.sh ]]; then
     SYSLOGPID="${PPID}..$$"
 fi
-INFO="${0##*/} - $USER - [${SYSLOGPID}] - INFO"
-ERROR="${0##*/} - $USER - [${SYSLOGPID}] - ERROR"
+comment="manual db deploy"
+if [ ! -z ${message} ]; then
+    comment="${message}"
+fi
+
+INFO="${0##*/} - ${USER} - ${comment} - [${SYSLOGPID}] - INFO"
+ERROR="${0##*/} - ${USER} - ${comment} - [${SYSLOGPID}] - ERROR"
 
 COMMAND="${0##*/} $* (pid: $$)"
 locktext="${0##*/} - [$$] locked by ${USER} ${COMMAND} @ $(date +"%F %T")"


### PR DESCRIPTION
parameter value will be added to syslog output and can be used to identify automatic data deploys
the default value is "manual deploy"

``` bash
$ bash deploy.sh -s source_db -t targed 
```

will be logged like:

```
Jul  3 09:02:55 ip-10-220-5-39.eu-west-1.compute.internal deploy.sh - ltclm - manual db deploy - [32485] - INFO: ....
```

``` bash
$ bash deploy.sh -s source_db -t targed -m "special deploy"
```

will be logged like:

```
Jul  3 09:02:55 ip-10-220-5-39.eu-west-1.compute.internal deploy.sh - ltclm - special deploy - [32485] - INFO: ....
```
