### PR TITLE
optional list of slaves to wait for before starting dml and ddl trigger

### DIFF
--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -135,9 +135,16 @@ check_env() {
         failed=true
     fi   
     # SPHINX DEMO, has to be set, can be empty
-    if [[ -z "${SPHINX_DEMO+x}" ]]; then
+    if [[ -z "${SPHINX_DEMO}" ]]; then
         echo 'export env variable containing SPHINX DEMO ip address (space delimiter): $ export SPHINX_DEMO="ipaddress1 ipaddress2"' >&2
         failed=true
+    fi
+    # PUBLISHED SLAVES set to default value if empty
+    # pipe delimited list of published slaves ips p.e. "ip1|ip2|ip3"
+    # the deploy script will wait for these slaves to by in-sync before starting the dml (sphinx) trigger
+    # normally these list should contain the ip's behind pg-sandbox.bgdi.ch and pg.bgdi.ch, default value is '.*' = all slaves
+    if [[ -z "${PUBLISHED_SLAVES}" ]];then
+        PUBLISHED_SLAVES='.*'
     fi
     if [[ "${failed}" = true ]];then
         echo "you can set the variables in ${MY_DIR}/deploy.cfg" 


### PR DESCRIPTION
this pr will allow us to define the list of slave ips to wait for during the deploy.
Actually the script is waiting for all the attached replication slaves before starting the dml and ddl trigger scripts. We will have more and more slaves (wms tile generation, internal slave, etc.) which we dont have to wait.
For the sphinx index update we only have to wait for the slave behind pg-sandbox.bgdi.ch, 
