### PR TITLE
use single branch bod_review with tags

### DIFF
--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -268,10 +268,8 @@ copy_database() {
     if [[ ${source_db} =~ ${REGEX} ]]; then
         echo "bash bod_review.sh -d ${source_db} ..."
         bash "${MY_DIR}/bod_review.sh" -d ${source_db} 1>&5 2>&6
-        for review_db in bod_dev bod_int bod_prod; do
-            echo "bash bod_review.sh -d ${review_db} ..."
-            bash "${MY_DIR}/bod_review.sh" -d ${review_db} 1>&5 2>&6
-        done
+        echo "bash bod_review.sh -d ${target_db} ..."
+        bash "${MY_DIR}/bod_review.sh" -d ${target_db} 1>&5 2>&6
     fi
 }
 


### PR DESCRIPTION
use a single branch bod_review with tags
new: https://github.com/geoadmin/db/compare/tag_bod_master...tag_bod_prod
old: https://github.com/geoadmin/db/compare/bod_master...bod_prod

con: 
- tags are not visible in the github compare tool
- diff looks the same +/- seems to be mixed up too

pro: 
- less code in bod_review.sh
- one branch with n tags instead of n branches
