### PR TITLE
enables target_db lock files

### DIFF
--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -375,6 +375,7 @@ copy_table() {
 # check locks
 # Globals:
 #   array_source
+#   target
 # Arguments:
 #   None
 # Returns:
@@ -383,7 +384,7 @@ copy_table() {
 check_locks() {
     # check if there are any lock files for the source objects
     for source_object in "${array_source[@]}"; do
-        lockfile="${LOCK_DIR}/${source_object}.lock"
+        lockfile="${LOCK_DIR}/${source_object}_${target}.lock"
         if [ -f "${lockfile}" ]
         then
             echo "lock file has been found ${lockfile}" >&2
@@ -393,7 +394,7 @@ check_locks() {
     done
     # create lock files for all sources
     for source_object in "${array_source[@]}"; do
-        lockfile="${LOCK_DIR}/${source_object}.lock"
+        lockfile="${LOCK_DIR}/${source_object}_${target}.lock"
         cat << EOF >${lockfile}
 ${source_object} locked with command ${COMMAND} by user ${USER}
 EOF
@@ -404,6 +405,7 @@ EOF
 # clean locks
 # Globals:
 #   array_source
+#   target
 # Arguments:
 #   None
 # Returns:
@@ -412,7 +414,7 @@ EOF
 clean_locks() {
     echo "cleaning lock files"
     for source_object in "${array_source[@]}"; do
-        lockfile="${LOCK_DIR}/${source_object}.lock"
+        lockfile="${LOCK_DIR}/${source_object}_${target}.lock"
         rm -rf ${lockfile} &> /dev/null
     done
 }
@@ -472,7 +474,7 @@ attached_slaves=$(psql -qAt -h localhost -d postgres -c "SELECT count(1) from pg
 # manual deploy will be creating a lock file in tmp/ directory for each deploy source
 if [[ ${comment} == "manual db deploy"  ]]; then
     check_locks
-    trap clean_locks SIGHUP SIGINT SIGTERM INT TERM EXIT
+    trap clean_locks SIGHUP SIGINT SIGTERM SIGQUIT INT TERM EXIT
 fi
 
 # loop through source_object values

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -383,7 +383,7 @@ copy_table() {
 check_locks() {
     # check if there are any lock files for the source objects
     for source_object in "${array_source[@]}"; do
-        lockfile="${MY_DIR}/tmp/${source_object}.lock"
+        lockfile="${LOCK_DIR}/${source_object}.lock"
         if [ -f "${lockfile}" ]
         then
             echo "lock file has been found ${lockfile}" >&2
@@ -393,7 +393,7 @@ check_locks() {
     done
     # create lock files for all sources
     for source_object in "${array_source[@]}"; do
-        lockfile="${MY_DIR}/tmp/${source_object}.lock"
+        lockfile="${LOCK_DIR}/${source_object}.lock"
         cat << EOF >${lockfile}
 ${source_object} locked with command ${COMMAND} by user ${USER}
 EOF
@@ -412,7 +412,7 @@ EOF
 clean_locks() {
     echo "cleaning lock files"
     for source_object in "${array_source[@]}"; do
-        lockfile="${MY_DIR}/tmp/${source_object}.lock"
+        lockfile="${LOCK_DIR}/${source_object}.lock"
         rm -rf ${lockfile} &> /dev/null
     done
 }

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -384,11 +384,15 @@ copy_table() {
 #######################################
 write_lock() {
     local lockfile="${LOCK_DIR}/${target_db}.lock"
+    local timeout=3600  # max retry interval in seconds
+    local counter=0
+    local increment=5   # check every n seconds
     # if target db is locked enter loop and wait for lockfile
-    until [ ! -f ${lockfile} ]
+    until [ ! -f "${lockfile}" ] || [ "${counter}" -gt "${timeout}" ]
     do
-        echo "target db ${target_db} is locked, waiting for deploy process to finish"
-        sleep 5
+        echo "target db ${target_db} is locked, waiting for deploy process to finish (${counter}/${timeout}) ..."
+        sleep ${increment}
+        (( counter += increment ))
     done
 
     # create lock files for target db

--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -19,8 +19,6 @@ INFO="${0##*/} - ${USER} - ${comment} - [${SYSLOGPID}] - INFO"
 ERROR="${0##*/} - ${USER} - ${comment} - [${SYSLOGPID}] - ERROR"
 
 COMMAND="${0##*/} $* (pid: $$)"
-locktext="${0##*/} - [$$] locked by ${USER} ${COMMAND} @ $(date +"%F %T")"
-lockfile="/tmp/db_deploy.lock"
 
 # coloured output
 red='\e[0;31m'

--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -111,6 +111,10 @@ check_env() {
         source "${MY_DIR}/deploy.cfg"
     fi
 
+    # check for lock dir, create it if it does not exist
+    LOCK_DIR="${MY_DIR}/tmp.lock"
+    [ -d ${LOCK_DIR} ] || mkdir ${LOCK_DIR}
+
     failed=false
     # DB superuser, set and not empty
     if [[ -z "${PGUSER}" ]]; then


### PR DESCRIPTION
**Description (outdated, see latest comments)** 
in case of a manual deploy for each deploy source, the script will create a lock file in tmp/ directory.
If any of the deploy sources is currently being deployed by a manual deploy, the script will be aborted.

this test will be done in the very beginning of the manual deploy. It should avoid the parallel deploy of the same sources.

For now the lock files are created for each deploy source. We could do the same but for the deploy targets. 

@gjn @loicgasser i let you decide.

p.e. the following manual deploy

``` bash
$ bash deploy.sh -s bod_master,evd_master.blw.klimaeignung -t dev
```

will create these lock files, if one of these lock files already exists, the script will be aborted:

``` bash
$ ls tmp/*.lock -lah
-rw-rw-r-- 1 geodata geodata 125 Oct 18 20:33 tmp/bod_master.lock
-rw-rw-r-- 1 geodata geodata 142 Oct 18 20:33 tmp/evd_master.blw.klimaeignung.lock
```

The lock files have the following content:

``` bash
$ cat tmp/bod_master.lock
bod_master locked with command deploy.sh -s bod_master,evd_master.blw.klimaeignung -t dev (pid: 16741) by user ltclm
```

The associated lock files are removed automatically when the manual deploy script finishes or crashes.
