### PR TITLE
allow reverse deploy of toposhop_prod to toposhop_dev and toposhop_int

### DIFF
--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -28,6 +28,7 @@ NC='\e[0m' # No Color
 
 # space delimited list of valid deploy targets, the target will be used as database suffix
 targets="dev int prod demo tile"
+targets_toposhop="dev int"
 
 #######################################
 # Logging


### PR DESCRIPTION
@pauloamado @hpchrist 
this pr will extend the default database deploy script with 
```bash
# toposhop_prod - > toposhop_int
bash deploy.sh -s toposhop_prod -t int
# toposhop_prod -> toposhop_dev
bash deploy.sh -s toposhop_prod -t dev
```

the script has to be executed as geodata on pg-0.dev.bgdi.ch