### PR TITLE
make sphinx index creation optional with new paramter -d (default true)

### DIFF
--- a/db_master_deploy/README.md
+++ b/db_master_deploy/README.md
@@ -5,7 +5,7 @@ The scripts have to be executed with ``geodata`` user. To become geodata you hav
 ```bash
 $ sudo su - geodata
 ```
-##Installation
+## Installation
 Clone the git repository to geodata's home:
 ```bash
 $ git clone git@github.com:geoadmin/deploy.git
@@ -15,7 +15,7 @@ Make sure that geodata .pgpass file exists. It should contain the credentials fo
 
 The script output will be written to syslog ``/var/log/messages`` and can be analyzed with kibana interface.
 
-###database naming convention and service address
+### database naming convention and service address
 The read-only hot-standby slaves can be accessed via this hostname: ``pg.bgdi.ch``
 Each database has to have one of the following suffixes
 
@@ -29,7 +29,7 @@ DB Suffix    | Meaning
 **_tile** |  tile copy of _master database, used for tile generation |
 **_``[a-zA-Z0-9]``+** | timestamped copy of _master database (bod only, use parameter -a [a-zA-Z0-9]+ for the archive suffix) |
 
-###copy databases and or tables (deploy.sh)
+### copy databases and or tables (deploy.sh)
 You can copy a comma delimited list of tables and/or database to one target. 
 The following targets can be used ``dev int prod demo tile``. 
 Normally we are deploying from a _master datasource to one of these targets. If you choose another source, the script will ask you for confirmation.
@@ -38,7 +38,7 @@ The job will be using all the available cores by splitting up the table into  pa
 
 Depending on the composition of the source_object parameter and the other parameters the script can be executed in the following modes:
 
-####table-copy
+#### table-copy
 ```bash
 $ bash deploy.sh -s stopo_master.tlm.strasse -t int
 ```
@@ -49,7 +49,7 @@ The script fires the sphinx trigger script dml_trigger.sh
 
 Database copy is is an optimized version of ``createdb -T source_db``.
 
-####database-copy 
+#### database-copy 
 Deploy bod to integration:
 ```bash
 $ bash deploy.sh -s bod_master -t int
@@ -63,13 +63,13 @@ Deploy bafu and stopo to production
 $ bash deploy.sh -s stopo_master,bafu_master -t prod
 ```
 
-####mixed copy database/table
+#### mixed copy database/table
 Deploy bod to integration:
 ```bash
 $ bash deploy.sh -s bod_master,stopo_master.tlm.strasse -t int
 ```
 
-####materialized views
+#### materialized views
 materialized views are updated by default during:
 * database deploy - before the deploy begins in the source database
 * table deploy - after the deploy in the target database
@@ -80,7 +80,7 @@ you can deactivate the materialized view update with the optional parameter ``-r
 $ bash deploy.sh -s stopo_master.tlm.strasse -t int -r false
 ```
 
-####bod archive
+#### bod archive
 Create an archive/snapshot of the BOD:
 ```bash
 bash deploy.sh -s bod_master -a 20150301
@@ -92,7 +92,7 @@ The deploy.sh script fires the sphinx trigger script dml_trigger.sh for table an
 
 The deploy.sh script fires the github trigger script ddl_trigger.sh for database copies only.
 
-###default data deploy worklow
+### default data deploy worklow
 ```
           +--------------+                                                                                    
           |              |                                                                                    
@@ -139,13 +139,14 @@ B    +--> |    _dev      |
 * New data will always be created on _master databases. The other databases are read-only. 
 * every deploy to prod has to be deployed to int first. It should always be in "pre-production" state.
 
-###dml trigger (dml_trigger.sh)
-SPHINX Index
+### dml trigger (dml_trigger.sh)
+**SPHINX Index**: 
+updating the sphinx indexes can be triggered with the optional parameter ``-d {true|false}``, default is ``true`` which means that the sphinx indexes will be updated.
 
-###ddl trigger (ddl_trigger.sh)
+### ddl trigger (ddl_trigger.sh)
 Update DDL dump Repository in Github https://github.com/geoadmin/db
 
-###custom master / slave postgres configuration
+### custom master / slave postgres configuration
 The following custom configuration should be present on the slaves behind pg.bgdi.ch:
 ```
 # https://github.com/geoadmin/deploy/issues/6


### PR DESCRIPTION
```bash
$ bash deploy.sh --help
Usage:
deploy.sh -s source_objects -t target_staging -a timestamp for BOD snapshot/archive (YYYYMMDD)
        -s comma delimited list of source databases and/or tables - mandatory
        -t target staging - mandatory choose one of 'dev int prod demo tile'
        -r refresh materialized views true|false - Optional, default: true'
        -d refresh sphinx indexes true|false - Optional, default: true'
        -a is optional and only valid for BOD, if you dont enter a target the script will just create an archive/snapshot copy of the bod

```

with the new parameter `` -d {true|false}`` you can turn on/off the sphinx index creation. default value is true -> sphinx indexes will be updated.

