### PR TITLE
add deploy.cfg

### DIFF
--- a/db_master_deploy/deploy.cfg
+++ b/db_master_deploy/deploy.cfg
@@ -1,0 +1,7 @@
+export SPHINX_DEV="10.220.4.145"
+export SPHINX_DEMO="10.220.4.145" #DEMO == DEV since at the moment not demo instance is active
+export SPHINX_INT="10.220.4.39"
+export SPHINX_PROD="10.220.5.210 10.220.6.242"
+export PGUSER=pgkogis
+#                        <-------pg.bgdi.ch------> <--pg-sandbox.bgdi.ch-->
+export PUBLISHED_SLAVES="10.220.5.122|10.220.6.137|10.220.5.87|10.220.6.129"


### PR DESCRIPTION
this pr adds deploy.cfg to repository
we have a history of the db deploy infra (sphinx instances, db slaves) which are important for the deploy script to work properly