### PR TITLE
BGDIINF_SB-1320 prepare db deploy scripts for aurora/rds

### DIFF
--- a/db_master_deploy/deploy.cfg
+++ b/db_master_deploy/deploy.cfg
@@ -3,5 +3,3 @@ export SPHINX_DEMO="10.220.4.145" #DEMO == DEV since at the moment not demo inst
 export SPHINX_INT="10.220.5.245"
 export SPHINX_PROD="10.220.5.253 10.220.6.26"
 export PGUSER=pgkogis
-#                        <-------pg.bgdi.ch------> <--pg-sandbox.bgdi.ch-->
-export PUBLISHED_SLAVES="10.220.5.122|10.220.6.137|10.220.5.87|10.220.6.129"

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -383,7 +383,7 @@ copy_table() {
 
     echo "create indexes on ${target_id}"
     set +o pipefail
-    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c 'psql -X -h localhost -d $@ -c "{}"' -- "${target_db}" ) || true
+    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c 'psql -X -h ${AURORA_WRITER_HOST} -d $@ -c "{}"' -- "${target_db}" ) || true
     set -o pipefail
 
     if [ "${#foreign_keys[@]}" -gt 0 ]; then
@@ -634,13 +634,6 @@ if [ "${#array_matviews[@]}" -gt "0" ]; then
     array_matviews=($(printf "%s\n" "${array_matviews[@]}" | sort -u));
     update_materialized_views table_commit
 fi
-
-# create new xlog position
-PSQL -qAt -d template1 -c "SELECT pg_switch_xlog();" > /dev/null
-# read new xlog position
-MASTER_XLOG=$(PSQL -qAt -d template1 -c "SELECT pg_current_xlog_location();")
-
-echo "master has been updated in $(format_milliseconds $((END-START))) to xlog position: ${MASTER_XLOG}"
 
 # concatenate arrays for dml and ddl trigger
 source_db=$(IFS=, ; echo "${array_source_db[*]}")

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -576,7 +576,6 @@ refreshsphinx=${refreshsphinx:-true}
 
 CPUS=$(grep -c "processor" < /proc/cpuinfo) || CPUS=1
 START=$(date +%s%3N)
-attached_slaves=$(PSQL -qAt -d postgres -c "SELECT count(1) from pg_stat_replication where state IN ('streaming') and client_addr::text ~* '${PUBLISHED_SLAVES}';")
 
 echo "start ${COMMAND}"
 check_input
@@ -642,29 +641,6 @@ PSQL -qAt -d template1 -c "SELECT pg_switch_xlog();" > /dev/null
 MASTER_XLOG=$(PSQL -qAt -d template1 -c "SELECT pg_current_xlog_location();")
 
 echo "master has been updated in $(format_milliseconds $((END-START))) to xlog position: ${MASTER_XLOG}"
-echo "waiting for ${attached_slaves} slaves with ip pattern '${PUBLISHED_SLAVES}' to be pushed to xlog position ${MASTER_XLOG}..."
-
-# wait for all slaves until they have replayed the new xlog
-while :
-do
-    diff=999
-    read slaves diff <<< "$(PSQL \
-    -X \
-    -d postgres \
-    --single-transaction \
-    --set ON_ERROR_STOP=on \
-    --no-align \
-    -t \
-    --field-separator ' ' \
-    --quiet \
-    -c "select count(1) as slaves, coalesce(sum(CASE WHEN diff >= 0 then diff ELSE NULL END)) as diff FROM ( SELECT pg_xlog_location_diff('${MASTER_XLOG}',replay_location) as diff from pg_stat_replication where state IN ('streaming') and client_addr::text ~* '${PUBLISHED_SLAVES}' ) sub;")"
-
-    if [[ ${diff} -eq 0 ]]; then
-        END_slaves=$(date +%s%3N)
-        echo "${slaves} slaves have been updated in $(format_milliseconds $((END_slaves-END))) to xlog position: ${MASTER_XLOG}"
-        break
-    fi
-done
 
 # concatenate arrays for dml and ddl trigger
 source_db=$(IFS=, ; echo "${array_source_db[*]}")

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -383,7 +383,7 @@ copy_table() {
 
     echo "create indexes on ${target_id}"
     set +o pipefail
-    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c 'psql -X -h ${AURORA_WRITER_HOST} -d $@ -c "{}"' -- "${target_db}" ) || true
+    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c 'psql -X -h "${AURORA_WRITER_HOST}" -d $@ -c "{}"' -- "${target_db}" ) || true
     set -o pipefail
 
     if [ "${#foreign_keys[@]}" -gt 0 ]; then
@@ -634,6 +634,8 @@ if [ "${#array_matviews[@]}" -gt "0" ]; then
     array_matviews=($(printf "%s\n" "${array_matviews[@]}" | sort -u));
     update_materialized_views table_commit
 fi
+
+echo "master has been updated in $(format_milliseconds $((END-START)))"
 
 # concatenate arrays for dml and ddl trigger
 source_db=$(IFS=, ; echo "${array_source_db[*]}")

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -383,7 +383,7 @@ copy_table() {
 
     echo "create indexes on ${target_id}"
     set +o pipefail
-    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c 'psql -X -h "${AURORA_WRITER_HOST}" -d $@ -c "{}"' -- "${target_db}" ) || true
+    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c "psql -X -h ${AURORA_WRITER_HOST} -d \$@ -c \"{}\"" -- "${target_db}" ) || true
     set -o pipefail
 
     if [ "${#foreign_keys[@]}" -gt 0 ]; then

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -383,7 +383,7 @@ copy_table() {
 
     echo "create indexes on ${target_id}"
     set +o pipefail
-    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c "psql -X -h ${AURORA_WRITER_HOST} -d \$@ -c \"{}\"" -- "${target_db}" ) || true
+    ( PG_DUMP --if-exists -c -t "${source_schema}.${source_table}" -s "${source_db}" 2>/dev/null | egrep -i "\bcreate\b" | egrep -i "\bindex\b" | sed "s/^/set search_path = ${source_schema}, public, pg_catalog; /" | sed "s/'/\\\'/g" | xargs --max-procs=${jobs} -I '{}' sh -c "psql -X -h ${RDS_WRITER_HOST} -d \$@ -c \"{}\"" -- "${target_db}" ) || true
     set -o pipefail
 
     if [ "${#foreign_keys[@]}" -gt 0 ]; then
@@ -652,7 +652,7 @@ if [[ -z "${ArchiveMode}" && -z "${ToposhopMode}" ]]; then
         # fire ddl trigger in sub shell
         # redirect customized stdout and stderr to standard ones
         (
-        [[ ! ${target} == tile ]] &&  bash "${MY_DIR}/ddl_trigger.sh" -s "${source_db}" -t "${target}"
+        [[ ! ${target} == tile ]] && echo  bash "${MY_DIR}/ddl_trigger.sh" -s "${source_db}" -t "${target}"
         )
     fi
 fi

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -652,7 +652,7 @@ if [[ -z "${ArchiveMode}" && -z "${ToposhopMode}" ]]; then
         # fire ddl trigger in sub shell
         # redirect customized stdout and stderr to standard ones
         (
-        [[ ! ${target} == tile ]] && echo  bash "${MY_DIR}/ddl_trigger.sh" -s "${source_db}" -t "${target}"
+        [[ ! ${target} == tile ]] &&  bash "${MY_DIR}/ddl_trigger.sh" -s "${source_db}" -t "${target}"
         )
     fi
 fi

--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -168,13 +168,6 @@ check_env() {
         echo 'export env variable containing SPHINX DEMO ip address (space delimiter): $ export SPHINX_DEMO="ipaddress1 ipaddress2"' >&2
         failed=true
     fi
-    # PUBLISHED SLAVES set to default value if empty
-    # pipe delimited list of published slaves ips p.e. "ip1|ip2|ip3"
-    # the deploy script will wait for these slaves to by in-sync before starting the dml (sphinx) trigger
-    # normally these list should contain the ip's behind pg-sandbox.bgdi.ch and pg.bgdi.ch, default value is '.*' = all slaves
-    if [[ -z "${PUBLISHED_SLAVES}" ]];then
-        PUBLISHED_SLAVES='.*'
-    fi
     if [[ "${failed}" = true ]];then
         echo "you can set the variables in ${MY_DIR}/deploy.cfg" >&2
         exit 1

--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -6,6 +6,7 @@ USER=$(logname) # get user behind sudo su -
 # if trigger script is called by deploy.sh, log parents pid in syslog
 # PARENT_COMMAND: you will get empty_string if it was invoked by user and name_of_calling_script if it was invoked by other script.
 PARENT_COMMAND=$(ps $PPID | tail -n 1 | awk "{print \$6}")
+AURORA_WRITER_HOST="database-1.cluster-cykjz246bryn.eu-west-1.rds.amazonaws.com"
 SYSLOGPID=$$
 
 comment="manual db deploy"
@@ -18,19 +19,19 @@ ERROR="${0##*/} - ${USER} - ${comment} - [${SYSLOGPID}] - ERROR"
 
 COMMAND="${0##*/} $* (pid: $$)"
 PSQL() {
-    psql -X -h localhost "$@"
+    psql -X -h ${AURORA_WRITER_HOST} "$@"
 }
 
 DROPDB() {
-    dropdb -h localhost "$@"
+    dropdb -h ${AURORA_WRITER_HOST} "$@"
 }
 
 CREATEDB() {
-   createdb -h localhost "$@"
+   createdb -h ${AURORA_WRITER_HOST} "$@"
 }
 
 PG_DUMP() {
-    pg_dump -h localhost "$@"
+    pg_dump -h ${AURORA_WRITER_HOST} "$@"
 }
 
 SSH="ssh -i /home/geodata/.ssh/id_rsa_new -o StrictHostKeyChecking=no -F /dev/null -A"

--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -6,7 +6,7 @@ USER=$(logname) # get user behind sudo su -
 # if trigger script is called by deploy.sh, log parents pid in syslog
 # PARENT_COMMAND: you will get empty_string if it was invoked by user and name_of_calling_script if it was invoked by other script.
 PARENT_COMMAND=$(ps $PPID | tail -n 1 | awk "{print \$6}")
-AURORA_WRITER_HOST="database-1.cluster-cykjz246bryn.eu-west-1.rds.amazonaws.com"
+RDS_WRITER_HOST="master.chtopodb.bgdi.ch"
 SYSLOGPID=$$
 
 comment="manual db deploy"
@@ -19,19 +19,19 @@ ERROR="${0##*/} - ${USER} - ${comment} - [${SYSLOGPID}] - ERROR"
 
 COMMAND="${0##*/} $* (pid: $$)"
 PSQL() {
-    psql -X -h ${AURORA_WRITER_HOST} "$@"
+    psql -X -h ${RDS_WRITER_HOST} "$@"
 }
 
 DROPDB() {
-    dropdb -h ${AURORA_WRITER_HOST} "$@"
+    dropdb -h ${RDS_WRITER_HOST} "$@"
 }
 
 CREATEDB() {
-   createdb -h ${AURORA_WRITER_HOST} "$@"
+   createdb -h ${RDS_WRITER_HOST} "$@"
 }
 
 PG_DUMP() {
-    pg_dump -h ${AURORA_WRITER_HOST} "$@"
+    pg_dump -h ${RDS_WRITER_HOST} "$@"
 }
 
 SSH="ssh -i /home/geodata/.ssh/id_rsa_new -o StrictHostKeyChecking=no -F /dev/null -A"

--- a/db_master_deploy/spec/db_master_deploy_spec.sh
+++ b/db_master_deploy/spec/db_master_deploy_spec.sh
@@ -34,7 +34,6 @@ default_env() {
   SPHINX_INT="ip-int"
   SPHINX_PROD="ip-prod-1 ip-prod-2"
   SPHINX_DEMO="ip-demo"
-  PUBLISHED_SLAVES="ip-1|ip-2|ip-3|ip-4"
 }
 
 add_deploy_config() {
@@ -44,8 +43,6 @@ export SPHINX_DEMO="10.220.4.145" #DEMO == DEV since at the moment not demo inst
 export SPHINX_INT="10.220.5.245"
 export SPHINX_PROD="10.220.5.253 10.220.6.26"
 export PGUSER=pgkogis
-#                        <-------pg.bgdi.ch------> <--pg-sandbox.bgdi.ch-->
-export PUBLISHED_SLAVES="10.220.5.122|10.220.6.137|10.220.5.87|10.220.6.129"
 EOF
 }
 
@@ -55,7 +52,6 @@ reset_env() {
   unset SPHINX_INT
   unset SPHINX_PROD
   unset SPHINX_DEMO
-  unset PUBLISHED_SLAVES
 }
 
 source_code() {
@@ -159,15 +155,6 @@ Describe 'includes.sh'
       When run check_env
       The status should be failure
       The stderr should include 'export SPHINX_DEMO='
-      mock_tear_down
-    End
-    Example 'missed PUBLISHED_SLAVES'
-      mock_set_up
-      default_env
-      unset PUBLISHED_SLAVES
-      When call check_env
-      The status should be success
-      The variable PUBLISHED_SLAVES should eq '.*'
       mock_tear_down
     End
     Example 'wrong user'


### PR DESCRIPTION
This will prepare the db deploy scripts for the usage with aurora / rds.

the host on which this script will run has to have the right postgres client installed:
`sudo apt-get install postgresql-client-11`

We will run this deploy script on geodatasync-0.prod.bgdi.ch once the aurora migration has been done.
We should install the postgresql-client-11 package there.