### PR TITLE
fix wrong exit status on full data deploy

### DIFF
--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -652,7 +652,7 @@ target_combined=$(IFS=, ; echo "${array_target_combined[*]}")
 # redirect customized stdout and stderr to standard ones
 if [[ -z "${ArchiveMode}" && -z "${ToposhopMode}" ]]; then
     (
-    [[ ! ${target} == tile && "${refreshsphinx}" =~ ^true$ ]] && bash "${MY_DIR}/dml_trigger.sh" -s "${target_combined}" -t "${target}"
+    [[ ! ${target} == tile && "${refreshsphinx}" =~ ^true$ ]] && bash "${MY_DIR}/dml_trigger.sh" -s "${target_combined}" -t "${target}" || :
     )
     if [ "${#array_target_db[@]}" -gt "0" ]
     then


### PR DESCRIPTION
this will fix the wrong exit status when doing full db deploy
and the ddl trigger will be executed again, it has been ignored until now when deploying with ``-d false`` option.

`installed here: [geodata@ip-10-220-5-150]:[~/deploy_ltclm/db_master_deploy`