### PR TITLE
BGDIINF_SB-2216: sphinx/dml trigger -> docker run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ swisstopo2integrationwithsnapshot.sh
 swisstopo2prod.sh
 .venv
 */tmp*/
+db_master_deploy/service-sphinxsearch/
+

--- a/db_master_deploy/deploy.cfg
+++ b/db_master_deploy/deploy.cfg
@@ -1,5 +1,1 @@
-export SPHINX_DEV="10.220.4.141"
-export SPHINX_DEMO="10.220.4.145" #DEMO == DEV since at the moment not demo instance is active
-export SPHINX_INT="10.220.5.245"
-export SPHINX_PROD="10.220.5.253 10.220.6.26"
 export PGUSER=pgkogis

--- a/db_master_deploy/dml_trigger.sh
+++ b/db_master_deploy/dml_trigger.sh
@@ -3,12 +3,9 @@
 # update sphinx index
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# SPHINX IP's
-SPHINX=${SPHINX_DEV};
-
-# SPHINX CONFIG AND TRIGGER
-SPHINX_PG_TRIGGER="/etc/sphinxsearch/pg2sphinx_trigger.py"
-SPHINX_CONFIG="/etc/sphinxsearch/sphinx.conf"
+SEARCH_GITHUB_BRANCH="develop-docker" # rename to master after migration to frankfurt
+SEARCH_GITHUB_REPO="git@github.com:geoadmin/service-sphinxsearch.git"
+SEARCH_GITHUB_FOLDER="${MY_DIR}/service-sphinxsearch"
 
 display_usage() {
     echo -e "Usage:\\n$0 -t tables/databases -s staging"
@@ -47,101 +44,35 @@ check_arguments() {
         echo "valid deploy targets are: '${targets}'" >&2
         exit 1
     fi
+}
 
-    case ${target} in
-        dev)
-            SPHINX=${SPHINX_DEV};
-            ;;
-
-        demo)
-            SPHINX=${SPHINX_DEMO};
-            ;;
-
-        int)
-            SPHINX=${SPHINX_INT};
-            ;;
-
-        prod)
-            SPHINX=${SPHINX_PROD};
-            ;;
-
-        *)
-            # shellcheck disable=SC2154
-            echo "there is no sphinx host defined for staging ${staging}" >&2
-            exit 1
-    esac
-
-    [[ ! -z "${SPHINX}" ]] || { echo "please define a sphinx host for ${target}" >&2; exit 1; }
+initialize_git() {
+    local folder repo branch
+    folder=$1
+    repo=$2
+    branch=$3
+    if [[ ! -d "${folder}" ]]; then
+        git clone -b "${branch}" "${repo}" "${folder}"
+    else
+        # silently get latest changes from remote
+        {
+        pushd "${folder}"
+        git checkout develop-docker
+        git fetch
+        git reset --hard origin/"${branch}"
+        popd
+        } &> /dev/null
+    fi
 }
 
 update_sphinx() {
-    echo "${SPHINX} (${tables} -> ${target})..."
     # connect to sphinx instance and update sphinx indexes
-    echo "Updating sphinx indexes"
-    echo "sphinx hosts: ${SPHINX}"
-    echo "db pattern: ${tables}"
-    for sphinx in ${SPHINX}
-    do
-        echo "opening ssh connection to ${target} sphinx host: ${sphinx} ..."
-        ${SSH} -T "${sphinx}" /bin/bash << HERE
-                start_sphinx() {
-                    echo "stopping sphinx with systemctl and searchd..."
-                    searchd --status &> /dev/null || sudo -u root systemctl stop sphinxsearch &> /dev/null
-                    searchd --status &> /dev/null || sudo -u sphinxsearch searchd --stopwait &> /dev/null
-                    sleep 2
-                    echo "starting sphinx with systemctl and searchd..."
-                    sudo -u root systemctl start sphinxsearch
-                    sudo -u sphinxsearch searchd &> /dev/null
-                    sleep 2;
-                    searchd --status;
-                    return \$?;
-                }
-
-                retry() {
-                # retry function or command some times
-                # \$1: mandatory command or function
-                    local retry=0
-                    local maxRetries=5
-                    local retryInterval=100
-                    local function="\$1"
-                    local return_code=0
-                    until [ \${retry} -ge "\${maxRetries}" ]
-                    do
-                        eval "\${function}" 2> /dev/null && break
-                        return_code=\$?
-                        retry=\$((retry+1))
-                        echo "Retrying '\${function}' [\${retry}/\${maxRetries}] in \${retryInterval}(s) "
-                        sleep "\${retryInterval}"
-                    done
-
-                    if [ \${retry} -ge "\${maxRetries}" ]; then
-                      eval "\${function}"
-                      return_code=\$?
-                      >&2 echo "Failed '\${function}' after \${maxRetries} attempts with return code \${return_code}!"
-                      exit 1
-                    fi
-                }
-
-                if [ -f ${SPHINX_CONFIG} ]; then
-                    # silent check of service status, if searchd is not responding stop and start systemctl and searchd
-                    if  ! searchd --status  &> /dev/null
-                    then
-                        echo "sphinx service was not running, trying to start sphinx service on host ${sphinx}"
-                        retry 'start_sphinx'
-                    fi
-                    echo "sphinx service status on host ${sphinx}:"
-                    # exit with error if service is still not running
-                    searchd --status &> /dev/null || { echo "Sphinx Service is not running on host ${sphinx}" >&2; searchd --status >&2; exit 1; }
-                    # update indexes
-                    echo "  update sphinx indexes that use the database source: ${tables} ..."
-                    python -u ${SPHINX_PG_TRIGGER} -d ${tables} -c update -s ${SPHINX_CONFIG}
-                    sleep 2
-                else
-                    echo "could not open sphinx config: ${SPHINX_CONFIG}" >&2
-                    exit 1
-                fi
-HERE
-    done
+    echo "Updating sphinx indexes on ${target} with db pattern ${tables}"
+    initialize_git "${SEARCH_GITHUB_FOLDER}" "${SEARCH_GITHUB_REPO}" "${SEARCH_GITHUB_BRANCH}"
+    # run docker command
+    pushd "${SEARCH_GITHUB_FOLDER}"
+    STAGING="${target}" DB="${tables}" make pg2sphinx
+    popd
 }
 
 # source script until here

--- a/db_master_deploy/dml_trigger.sh
+++ b/db_master_deploy/dml_trigger.sh
@@ -11,9 +11,9 @@ SPHINX_PG_TRIGGER="/etc/sphinxsearch/pg2sphinx_trigger.py"
 SPHINX_CONFIG="/etc/sphinxsearch/sphinx.conf"
 
 display_usage() {
-    echo -e "Usage:\n$0 -t tables/databases -s staging"
-    echo -e "\t-s comma delimited list of tables and/or databases - mandatory"
-    echo -e "\t-t target staging - mandatory choose one of '${targets}'"
+    echo -e "Usage:\\n$0 -t tables/databases -s staging"
+    echo -e "\\t-s comma delimited list of tables and/or databases - mandatory"
+    echo -e "\\t-t target staging - mandatory choose one of '${targets}'"
 }
 
 while getopts ":s:t:" options; do
@@ -66,6 +66,7 @@ check_arguments() {
             ;;
 
         *)
+            # shellcheck disable=SC2154
             echo "there is no sphinx host defined for staging ${staging}" >&2
             exit 1
     esac
@@ -145,6 +146,7 @@ HERE
 
 # source script until here
 [ "$0" = "${BASH_SOURCE[*]}" ] || return 0
+# shellcheck source=./includes.sh
 source "${MY_DIR}/includes.sh"
 check_env
 

--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -34,8 +34,6 @@ PG_DUMP() {
     pg_dump -h ${RDS_WRITER_HOST} "$@"
 }
 
-SSH="ssh -i /home/geodata/.ssh/id_rsa_new -o StrictHostKeyChecking=no -F /dev/null -o LogLevel=ERROR -A"
-
 # coloured output
 red='\e[0;31m'
 NC='\e[0m' # No Color
@@ -147,26 +145,6 @@ check_env() {
     # DB superuser, set and not empty
     if [[ -z "${PGUSER}" ]]; then
         echo 'export env variable containing DB Superuser name: $ export PGUSER=xxx' >&2
-        failed=true
-    fi
-    # SPHINX DEV, set and not empty
-    if [[ -z "${SPHINX_DEV}" ]]; then
-        echo 'export env variable containing SPHINX DEV ip address (space delimiter): $ export SPHINX_DEV="ipaddress1 ipaddress2"' >&2
-        failed=true
-    fi
-    # SPHINX INT, set and not empty
-    if [[ -z "${SPHINX_INT}" ]]; then
-        echo 'export env variable containing SPHINX INT ip address (space delimiter): $ export SPHINX_INT="ipaddress1 ipaddress2"' >&2
-        failed=true
-    fi
-    # SPHINX PROD, set and not empty
-    if [[ -z "${SPHINX_PROD}" ]]; then
-        echo 'export env variable containing SPHINX PROD ip address (space delimiter): $ export SPHINX_PROD="ipaddress1 ipaddress2"' >&2
-        failed=true
-    fi
-    # SPHINX DEMO, has to be set, can be empty
-    if [[ -z "${SPHINX_DEMO}" ]]; then
-        echo 'export env variable containing SPHINX DEMO ip address (space delimiter): $ export SPHINX_DEMO="ipaddress1 ipaddress2"' >&2
         failed=true
     fi
     if [[ "${failed}" = true ]];then

--- a/db_master_deploy/spec/db_master_deploy_spec.sh
+++ b/db_master_deploy/spec/db_master_deploy_spec.sh
@@ -30,28 +30,16 @@ whoami() {
 
 default_env() {
   PGUSER="www-data"
-  SPHINX_DEV="ip-dev"
-  SPHINX_INT="ip-int"
-  SPHINX_PROD="ip-prod-1 ip-prod-2"
-  SPHINX_DEMO="ip-demo"
 }
 
 add_deploy_config() {
   cat << EOF > ${deploy_config}
-export SPHINX_DEV="10.220.4.141"
-export SPHINX_DEMO="10.220.4.145" #DEMO == DEV since at the moment not demo instance is active
-export SPHINX_INT="10.220.5.245"
-export SPHINX_PROD="10.220.5.253 10.220.6.26"
 export PGUSER=pgkogis
 EOF
 }
 
 reset_env() {
   unset PGUSER
-  unset SPHINX_DEV
-  unset SPHINX_INT
-  unset SPHINX_PROD
-  unset SPHINX_DEMO
 }
 
 source_code() {
@@ -119,42 +107,6 @@ Describe 'includes.sh'
       When run check_env
       The status should be failure
       The stderr should include 'export PGUSER=xxx'
-      mock_tear_down
-    End
-    Example 'missed SPHINX_DEV'
-      mock_set_up
-      default_env
-      unset SPHINX_DEV
-      When run check_env
-      The status should be failure
-      The stderr should include 'export SPHINX_DEV='
-      mock_tear_down
-    End
-    Example 'missed SPHINX_INT'
-      mock_set_up
-      default_env
-      unset SPHINX_INT
-      When run check_env
-      The status should be failure
-      The stderr should include 'export SPHINX_INT='
-      mock_tear_down
-    End
-    Example 'missed SPHINX_PROD'
-      mock_set_up
-      default_env
-      unset SPHINX_PROD
-      When run check_env
-      The status should be failure
-      The stderr should include 'export SPHINX_PROD='
-      mock_tear_down
-    End
-    Example 'missed SPHINX_DEMO'
-      mock_set_up
-      default_env
-      unset SPHINX_DEMO
-      When run check_env
-      The status should be failure
-      The stderr should include 'export SPHINX_DEMO='
       mock_tear_down
     End
     Example 'wrong user'
@@ -726,12 +678,6 @@ Describe 'dml_trigger.sh'
       target="invalid_target"
       When run check_arguments
       The stderr should start with "valid deploy targets are:"
-      The status should be failure
-    End
-    Example 'missing sphinx host'
-      unset SPHINX_DEV
-      When run check_arguments
-      The stderr should eq "please define a sphinx host for ${target}"
       The status should be failure
     End
   End


### PR DESCRIPTION
With the new data workflow in frankfurt the database deploy script will trigger the sphinx index update with a local docker run command (make file target in [service-sphinxsearch](https://github.com/geoadmin/service-sphinxsearch) project).


- [x] scan for the deployed/published images on dev, int prod in infra-vhost repo
- [x] make pg2sphinx should choose the image for the sphinx index creation / update in this order:
        - aws ecr, pull image if exists (geodatasync instance role is needed for that https://jira.swisstopo.ch/browse/BGDIINF_SB-2366)
        - local image
        - run image and create/update index

to be merged together with https://github.com/geoadmin/service-sphinxsearch/pull/485