### PR TITLE
PB-81: as a temporary workaround the active service-search-sphinx image

### DIFF
--- a/db_master_deploy/dml_trigger.sh
+++ b/db_master_deploy/dml_trigger.sh
@@ -10,7 +10,7 @@ SEARCH_GITHUB_REPO="git@github.com:geoadmin/service-search-sphinx.git"
 SEARCH_GITHUB_FOLDER="/data/geodata/automata/service-search-sphinx"
 
 # sphinxsearch published versions
-K8S_GITHUB_BRANCH="feat_PB-82_search_k8s"
+K8S_GITHUB_BRANCH="master"
 K8S_GITHUB_REPO="git@github.com:geoadmin/infra-kubernetes.git"
 K8S_GITHUB_FOLDER="/data/geodata/automata/infra-kubernetes"
 


### PR DESCRIPTION
will be read from the repository

this workaround will be removed with one of the following approaches:
* index generation with kubernetes jobs
* kubernetes service role to read the image from the kubernetes resources