### PR TITLE
PB-964: update materialized views on source database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 CURRENT_DIRECTORY := $(shell pwd)
 INSTALL_DIRECTORY := $(CURRENT_DIRECTORY)/.venv
 PYTHON_FILES := $(shell find * -path .venv/ -prune -o -type f -name "*.py" -print)
-SHELLSPEC_VERSION := "0.20.2"
+SHELLSPEC_VERSION := "0.28.1"
 
 # install git hook with heredoc needs the following option
 .ONESHELL:

--- a/db_master_deploy/README.md
+++ b/db_master_deploy/README.md
@@ -22,14 +22,14 @@ Each database has to have one of the following suffixes
 DB Suffix    | Meaning
 -------------|------------|
 **_master** |  Original database, will be continuosly updated, should not be used in any applications |
-**_dev**   | development copy of _master database  | 
-**_int**   | integration copy of _master database | 
-**_prod**  | production copy of _master database  | 
+**_dev**   | read-only development copy of _master database  | 
+**_int**   | read-only integration copy of _master database | 
+**_prod**  | read-only production copy of _master database  | 
 **_``[a-zA-Z0-9]``+** | timestamped copy of _master database (bod only, use parameter -a [a-zA-Z0-9]+ for the archive suffix) |
 
 ### copy databases and or tables (deploy.sh)
 You can copy a comma delimited list of tables and/or database to one target. 
-The following targets can be used ``dev int prod demo tile``. 
+The following targets can be used ``dev int prod``. 
 Normally we are deploying from a _master datasource to one of these targets. If you choose another source, the script will ask you for confirmation.
 Table copy is performance optimized sql copy from stdout to stdin. 
 The job will be using all the available cores by splitting up the table into  parts with equal number of rows, indexes and constraints will be removed before writing the table and re-created afterwards.
@@ -76,8 +76,11 @@ $ bash deploy.sh -s bod_dev,stopo_dev.tlm.strasse -t int
 
 #### materialized views
 materialized views are updated by default during:
-* database deploy - before the deploy begins in the source database
+* full database deploy - before the deploy begins in the source database
 * table deploy - after the deploy in the target database
+* table deploy - in the source database if the deploy is from `master` to `dev`
+
+for the table deploy, only the materialized views which rely on the deployed tables will be updated.
 
 you can deactivate the materialized view update with the optional parameter ``-r false``  
 

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -518,7 +518,7 @@ check_toposhop() {
         # check if we have a valid standard deploy target
         if [[ ! ${targets} =~ ${target} ]]; then
             echo "valid standard deploy targets are: '${targets}'" >&2
-            #exit 0
+            exit 1
         fi
         unset ${ToposhopMode} &> /dev/null || :
     fi

--- a/db_master_deploy/deploy.sh
+++ b/db_master_deploy/deploy.sh
@@ -450,7 +450,7 @@ write_lock() {
     local uniq_db_target=()
     mapfile -t uniq_db_target < <(
         for source in "${array_source[@]}"; do
-            array=("${source//./ }")
+            array=(${source//./ })
             echo "${array[0]%_*}_${target:-${timestamp}}"
         done | sort | uniq
     )

--- a/db_master_deploy/spec/db_master_deploy_spec.sh
+++ b/db_master_deploy/spec/db_master_deploy_spec.sh
@@ -317,16 +317,31 @@ EOF
         The line 2 of stdout should eq "table_scan: skipping materialized view update on database ${source_db}"
         The status should be success
       End
-      Example 'update_materialized_views_table_commit'
+      Example 'update_materialized_views_table_commit dev'
         PSQL() {
           :
         }
+        target=dev
         When call update_materialized_views table_commit
         The stderr should not be present
         The line 1 of stdout should eq "table_commit: updating materialized view ${matview_1} in db ${target_db} ..."
         The line 2 of stdout should eq "table_commit: updating materialized view ${matview_2} in db ${target_db} ..."
         The line 3 of stdout should eq "table_commit: updating materialized view ${matview_1} in db ${source_db} ..."
         The line 4 of stdout should eq "table_commit: updating materialized view ${matview_2} in db ${source_db} ..."
+        The variable array_target_combined should include "${matview_1}"
+        The status should be success
+      End
+      Example 'update_materialized_views_table_commit int'
+        PSQL() {
+          :
+        }
+        target=int
+        When call update_materialized_views table_commit
+        The stderr should not be present
+        The line 1 of stdout should eq "table_commit: updating materialized view ${matview_1} in db ${target_db} ..."
+        The line 2 of stdout should eq "table_commit: updating materialized view ${matview_2} in db ${target_db} ..."
+        The line 3 of stdout should not eq "table_commit: updating materialized view ${matview_1} in db ${source_db} ..."
+        The line 4 of stdout should not eq "table_commit: updating materialized view ${matview_2} in db ${source_db} ..."
         The variable array_target_combined should include "${matview_1}"
         The status should be success
       End

--- a/db_master_deploy/spec/db_master_deploy_spec.sh
+++ b/db_master_deploy/spec/db_master_deploy_spec.sh
@@ -495,34 +495,6 @@ EOF
       End
       mock_tear_down
     End
-    Describe 'check_toposhop'
-      source_code includes.sh
-      Example 'standard deploy valid target'
-        target=dev
-        When call check_toposhop stopo_master
-        The status should be success
-        The variable ToposhopMode should not be defined
-      End
-      Example 'standard deploy invalid target'
-        target=invalid_target
-        When run check_toposhop stopo_master
-        The status should be failure
-        The stderr should eq "valid standard deploy targets are: 'dev int prod demo tile'"
-      End
-      Example 'toposhop deploy valid target'
-        target=dev
-        When call check_toposhop toposhop_prod
-        The status should be success
-        The stderr should not be present
-        The variable ToposhopMode should be defined
-      End
-      Example 'toposhop deploy invalid target'
-        target=prod
-        When run check_toposhop toposhop_prod
-        The status should be failure
-        The stderr should eq "valid toposhop deploy targets are: 'dev int'"
-      End
-    End
     Describe 'check_input'
       source_code includes.sh
       target=dev

--- a/db_master_deploy/spec/db_master_deploy_spec.sh
+++ b/db_master_deploy/spec/db_master_deploy_spec.sh
@@ -307,6 +307,16 @@ EOF
         The stdout should include "table_scan: found materialized view ${target_db}.${matview_1} which is referencing . ..."
         The status should be success
       End
+      Example 'update_materialized_views_table_scan_source_not_master'
+        source_db="bod_dev"
+        target_db="bod_int"
+        PSQL() {
+          echo "${matview_1}"
+        }
+        When run update_materialized_views table_scan
+        The line 2 of stdout should eq "table_scan: skipping materialized view update on database ${source_db}"
+        The status should be success
+      End
       Example 'update_materialized_views_table_commit'
         PSQL() {
           :


### PR DESCRIPTION
When deploying single tables to dev, int or prod, all the related materialized views should be updated on the source database and on the target database.

right now only the materialized views on the target database are being updated. Sooner or later the materialized views on the source database are outdated.

together with this data-update triggered approach we will activate a cron triggered update of all the materialized views in the source databases, see https://github.com/geoadmin/bgdi-scripts/pull/1690 
more context in the jira issue.