### PR TITLE
PB-992: support partitioned tables deploy

### DIFF
--- a/db_master_deploy/spec/db_master_deploy_spec.sh
+++ b/db_master_deploy/spec/db_master_deploy_spec.sh
@@ -269,6 +269,27 @@ EOF
         The stderr should equal "cannot copy table source_db.source_schema.source_table, table is referenced by 15 objects, use db_copy instead."
         The status should be failure
       End
+      Example 'check_table_partitions_true'
+        PSQL() {
+          echo 0
+        }
+        When run test_check_table check_table_partitions
+        The stdout should not be present
+        The stderr should not be present
+        The status should be success
+      End
+      Example 'check_table_dependencies_false'
+        PSQL() {
+          :
+        }
+        diff() {
+          return 1
+        }
+        When run test_check_table check_table_partitions
+        The stderr should equal "structure of source and target partitions is different."
+        The stdout should not be present
+        The status should be failure
+      End
     End
     Describe 'check_database'
       source_db="source_db"


### PR DESCRIPTION
The list of indexes to be created and dropped is built with pg_dump and
the name of the table as `-t "table-name"` parameter.

By default this is not dumping the Index Creation/Drop statements for paritioned table
children.

By changing the pg_dump paramater to `-t "table-name*"` index
creation/drop statements of the paritioned children tables are also
printed out and therefore used by the table deploy script.

additionally a check has been added. table deploy is only possible if
the partitions of the source and the target table are the same