### PR TITLE
PB-354: postgres 16 optimizations

### DIFF
--- a/db_master_deploy/includes.sh
+++ b/db_master_deploy/includes.sh
@@ -27,7 +27,7 @@ DROPDB() {
 }
 
 CREATEDB() {
-   createdb -h ${RDS_WRITER_HOST} "$@"
+   createdb -h ${RDS_WRITER_HOST} --strategy=file_copy "$@"
 }
 
 PG_DUMP() {


### PR DESCRIPTION
postgres 16 offers the choice of  a strategy for the created copy

command, the default strategy wal_log is very slow for bigger databases compared to the old strategy file_copy.

bafu_master 30 GB
file_copy: 2m
wal_log: 30m

:warning:  NOT TO BE MERGED BEFORE PG 16 MIGRATION IS FINISHED