### PR TITLE
PB-504: read sphinx version from wsgi info endpoint

### DIFF
--- a/db_master_deploy/dml_trigger.sh
+++ b/db_master_deploy/dml_trigger.sh
@@ -4,12 +4,12 @@
 
 MY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# shpinxsearch makefile
+# sphinxsearch makefile
 SEARCH_GITHUB_BRANCH="master"
 SEARCH_GITHUB_REPO="git@github.com:geoadmin/service-search-sphinx.git"
 SEARCH_GITHUB_FOLDER="/data/geodata/automata/service-search-sphinx"
 
-# global variable set by get_sphinx_image_tag function
+# global variable set by get_sphinx_image_tag function
 SPHINX_IMAGE_TAG=""
 
 display_usage() {
@@ -51,7 +51,7 @@ done
 check_arguments() {
     # check for mandatory arguments
     if [[ -z "${target}" || -z "${tables}" ]]; then
-        echo "missing a required parameter (source_db -s and taget_db -t are required)" >&2
+        echo "missing a required parameter (source_db -s and target_db -t are required)" >&2
         display_usage
         exit 1
     fi
@@ -105,19 +105,19 @@ get_service_search_sphinx_version() {
 
     # Fetch the JSON data from the URL
     if ! json_data=$(curl --silent --fail "${url}"); then
-        >&2 echo "Failed to fetch data from ${url}"
+        echo >&2 "Failed to fetch data from ${url}"
         exit 1
     fi
 
     # Extract the version number using jq
     if ! version=$(echo "${json_data}" | jq -r '.[] | select(.name == "service-search-sphinx") | .version' 2>&1); then
-        >&2 echo "Failed to parse JSON data, error: ${version}"
+        echo >&2 "Failed to parse JSON data, error: ${version}"
         exit 1
     fi
 
     # Check if the version is empty
     if [[ -z "${version}" ]]; then
-        >&2 echo "No version found for service-search-sphinx in the JSON data"
+        echo >&2 "No version found for service-search-sphinx in the JSON data"
         exit 1
     fi
 
@@ -127,11 +127,11 @@ get_service_search_sphinx_version() {
 
 update_sphinx() {
     ########################################
-    # update the sphinx indexes
+    # update the sphinx indexes
     ########################################
     echo "Updating sphinx indexes on ${target} with db pattern ${tables} using sphinx image: ${SPHINX_IMAGE_TAG}"
     initialize_git "${SEARCH_GITHUB_FOLDER}" "${SEARCH_GITHUB_REPO}" "${SEARCH_GITHUB_BRANCH}" || :
-    # run docker command
+    # run docker command
     pushd "${SEARCH_GITHUB_FOLDER}" || exit
     TERM=xterm DOCKER_LOCAL_TAG="${SPHINX_IMAGE_TAG}" STAGING="${target}" DB="${tables}" make pg2sphinx
     popd || exit

--- a/db_master_deploy/dml_trigger.sh
+++ b/db_master_deploy/dml_trigger.sh
@@ -9,13 +9,6 @@ SEARCH_GITHUB_BRANCH="master"
 SEARCH_GITHUB_REPO="git@github.com:geoadmin/service-search-sphinx.git"
 SEARCH_GITHUB_FOLDER="/data/geodata/automata/service-search-sphinx"
 
-# sphinxsearch published versions
-K8S_GITHUB_BRANCH="master"
-K8S_GITHUB_REPO="git@github.com:geoadmin/infra-kubernetes.git"
-K8S_GITHUB_FOLDER="/data/geodata/automata/infra-kubernetes"
-
-YQ="docker run --rm -i 974517877189.dkr.ecr.eu-central-1.amazonaws.com/external/openapi/yq:4.44.1"
-
 # global variable set by get_sphinx_image_tag function
 SPHINX_IMAGE_TAG=""
 
@@ -24,6 +17,16 @@ display_usage() {
     echo -e "\\t-s comma delimited list of tables and/or databases - mandatory"
     # shellcheck disable=SC2154
     echo -e "\\t-t target staging - mandatory choose one of '${targets}'"
+}
+
+validate_dependencies() {
+    local dependencies=("git" "curl" "jq" "make" "docker")
+    for dep in "${dependencies[@]}"; do
+        if ! command -v "${dep}" &>/dev/null; then
+            echo "Error: ${dep} is not installed." >&2
+            exit 1
+        fi
+    done
 }
 
 while getopts ":s:t:" options; do
@@ -82,26 +85,44 @@ initialize_git() {
     fi
 }
 
-get_sphinx_image_tag() {
+get_service_search_sphinx_version() {
     ########################################
-    # gets the sphinx image tag from the infra-kubernetes repo for the given staging
-    # and saves the tag in the global variable SPHINX_IMAGE_TAG
+    # gets the version number of service-search-sphinx from the JSON file
+    # located at the provided URL
     ########################################
     local staging=$1
-    local config_file
-    initialize_git "${K8S_GITHUB_FOLDER}" "${K8S_GITHUB_REPO}" "${K8S_GITHUB_BRANCH}" || :
+    local url="https://sys-api3.${staging}.bgdi.ch/rest/services/ech/SearchServer/info"
+    local prefix=""
+    local version
+    local json_data
 
-    [[ ${staging} == "dev" ]] && config_file="${K8S_GITHUB_FOLDER}/services/service-search/overlays/dev/patch-image-service-search-sphinx.yaml"
-    [[ ${staging} == "int" ]] && config_file="${K8S_GITHUB_FOLDER}/services/service-search/overlays/int/patch-image-service-search-sphinx.yaml"
-    [[ ${staging} == "prod" ]] && config_file="${K8S_GITHUB_FOLDER}/services/service-search/base/patch-image-service-search-sphinx.yaml"
+    # milestone beta images are prefixed with dev- for ecr lifecycle policy
+    [[ ${staging} == "dev" ]] && prefix="dev-"
 
-    if image_tag=$(${YQ} '.imageTag.newTag' <"${config_file}"); then
-        SPHINX_IMAGE_TAG="${image_tag}"
-    else
-        exitstatus=$?
-        >&2 echo "no image tag found for staging ${staging}"
-        exit ${exitstatus}
+    if [[ ${staging} == "prod" ]]; then
+        url="https://api3.geo.admin.ch/rest/services/ech/SearchServer/info"
     fi
+
+    # Fetch the JSON data from the URL
+    if ! json_data=$(curl --silent --fail "${url}"); then
+        >&2 echo "Failed to fetch data from ${url}"
+        exit 1
+    fi
+
+    # Extract the version number using jq
+    if ! version=$(echo "${json_data}" | jq -r '.[] | select(.name == "service-search-sphinx") | .version' 2>&1); then
+        >&2 echo "Failed to parse JSON data, error: ${version}"
+        exit 1
+    fi
+
+    # Check if the version is empty
+    if [[ -z "${version}" ]]; then
+        >&2 echo "No version found for service-search-sphinx in the JSON data"
+        exit 1
+    fi
+
+    echo "found this version for service-search-sphinx in url ${url} : ${prefix}${version}"
+    SPHINX_IMAGE_TAG="${prefix}${version}"
 }
 
 update_sphinx() {
@@ -120,13 +141,14 @@ update_sphinx() {
 [ "$0" = "${BASH_SOURCE[*]}" ] || return 0
 # shellcheck source=./includes.sh
 source "${MY_DIR}/includes.sh"
+validate_dependencies
 check_env
 check_arguments
 
 START_DML=$(date +%s%3N)
 echo "$(date +"[%F %T]") start ${COMMAND}"
 check_arguments
-get_sphinx_image_tag "${target}"
+get_service_search_sphinx_version "${target}"
 update_sphinx
 END_DML=$(date +%s%3N)
 echo "$(date +"[%F %T]") finished ${COMMAND} in $(format_milliseconds $((END_DML - START_DML)))"


### PR DESCRIPTION
Switch get_service_search_sphinx_version function from yq parsing to URL JSON parsing and improve robustness

- Changed the function to fetch JSON data from the provided URL instead of using yq parsing from the git repo.
- Added error handling for curl to ensure data is fetched successfully from the URL.
- Added error handling for jq to ensure JSON data is parsed correctly.
- Added validation to check if the extracted version is empty.
- Improved error messages for better debugging.

These changes make the function more robust and ensure it handles errors gracefully.

:warning:  not to be merged before the next milestone deploy : 2025-05-14